### PR TITLE
Add addslashes to $_REQUEST

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -7,7 +7,7 @@ class Request extends Base
     
     public function pollute()
     {
-        if (magicQuotesGpc) {
+        if ($this->magicQuotesGpc) {
             $this->applyMagicQuotesGpc();
         }
         $this->injectFileToGlobal();

--- a/src/Request.php
+++ b/src/Request.php
@@ -7,6 +7,9 @@ class Request extends Base
     
     public function pollute()
     {
+        if (magicQuotesGpc) {
+            $this->applyMagicQuotesGpc();
+        }
         $this->injectFileToGlobal();
         $this->injectEGPCSToGlobal();
     }
@@ -77,24 +80,12 @@ class Request extends Base
                     $this->injectToGlobal($_ENV);
                     break;
                 case 'g':
-                    if ($this->magicQuotesGpc) {
-                        $this->addSlashesRecursive($_GET);
-                        $_REQUEST = array_merge($_REQUEST, $_GET);
-                    }
                     $this->injectToGlobal($_GET);
                     break;
                 case 'p':
-                    if ($this->magicQuotesGpc) {
-                        $this->addSlashesRecursive($_POST);
-                        $_REQUEST = array_merge($_REQUEST, $_POST);
-                    }
                     $this->injectToGlobal($_POST);
                     break;
                 case 'c':
-                    if ($this->magicQuotesGpc) {
-                        $this->addSlashesRecursive($_COOKIE);
-                        $_REQUEST = array_merge($_REQUEST, $_COOKIE);
-                    }
                     $this->injectToGlobal($_COOKIE);
                     break;
                 case 's':
@@ -142,5 +133,13 @@ class Request extends Base
                 $GLOBALS[$name] = $value;
             }
         }
+    }
+
+    private function applyMagicQuotesGpc()
+    {
+        $this->addSlashesRecursive($_GET);
+        $this->addSlashesRecursive($_POST);
+        $this->addSlashesRecursive($_COOKIE);
+        $this->addSlashesRecursive($_REQUEST);
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -101,6 +101,8 @@ class Request extends Base
 
             $injectedFlag[$name] = true;
         }
+
+        $_REQUEST = array_merge($_GET, $_POST, $_COOKIE);
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -79,18 +79,21 @@ class Request extends Base
                 case 'g':
                     if ($this->magicQuotesGpc) {
                         $this->addSlashesRecursive($_GET);
+                        $_REQUEST = array_merge($_REQUEST, $_GET);
                     }
                     $this->injectToGlobal($_GET);
                     break;
                 case 'p':
                     if ($this->magicQuotesGpc) {
                         $this->addSlashesRecursive($_POST);
+                        $_REQUEST = array_merge($_REQUEST, $_POST);
                     }
                     $this->injectToGlobal($_POST);
                     break;
                 case 'c':
                     if ($this->magicQuotesGpc) {
                         $this->addSlashesRecursive($_COOKIE);
+                        $_REQUEST = array_merge($_REQUEST, $_COOKIE);
                     }
                     $this->injectToGlobal($_COOKIE);
                     break;
@@ -101,8 +104,6 @@ class Request extends Base
 
             $injectedFlag[$name] = true;
         }
-
-        $_REQUEST = array_merge($_GET, $_POST, $_COOKIE);
     }
 
     /**

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -106,6 +106,8 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("baz\'piyo", $_GET['secret_id']);
         $this->assertEquals("\'Okinawa\'", $secret_info['address']);
         $this->assertEquals("\'Okinawa\'", $_GET['secret_info']['address']);
+        $this->assertEquals("baz\'piyo", $_REQUEST['secret_id']);
+        $this->assertEquals("\'Okinawa\'", $_REQUEST['secret_info']['address']);
     }
 
     /**

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -178,6 +178,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $_POST['personal_info_2'] = array('address' => "'Tokyo'");
         $_COOKIE['name_3'] = "baz'piyo_cookie";
         $_COOKIE['personal_info_3'] = array('address' => "'Kanagawa'");
+        $_REQUEST = array_merge($_GET, $_POST, $_COOKIE);
 
         $this->setVariablesOrder('egpc');
         $this->object->enableMagicQuotesGpc();

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -90,10 +90,14 @@ class RequestTest extends PHPUnit_Framework_TestCase
     public function testPolluteEnableMagicQuotesGpc()
     {
         $_ENV['TOKEN'] = "foo'bar";
-        $_GET['secret_id'] = "baz'piyo";
-        $_GET['secret_info'] = array('address' => "'Okinawa'");
-        
-        $this->setVariablesOrder('eg');
+        $_GET['name_1'] = "baz'piyo_get";
+        $_GET['personal_info_1'] = array('address' => "'Okinawa'");
+        $_POST['name_2'] = "baz'piyo_post";
+        $_POST['personal_info_2'] = array('address' => "'Tokyo'");
+        $_COOKIE['name_3'] = "baz'piyo_cookie";
+        $_COOKIE['personal_info_3'] = array('address' => "'Kanagawa'");
+
+        $this->setVariablesOrder('egpc');
         $this->object->enableMagicQuotesGpc();
         $this->object->pollute();
 
@@ -101,13 +105,28 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("foo'bar", $TOKEN);
         $this->assertEquals("foo'bar", $_ENV['TOKEN']);
 
-        global $secret_id, $secret_info;
-        $this->assertEquals("baz\'piyo", $secret_id);
-        $this->assertEquals("baz\'piyo", $_GET['secret_id']);
-        $this->assertEquals("\'Okinawa\'", $secret_info['address']);
-        $this->assertEquals("\'Okinawa\'", $_GET['secret_info']['address']);
-        $this->assertEquals("baz\'piyo", $_REQUEST['secret_id']);
-        $this->assertEquals("\'Okinawa\'", $_REQUEST['secret_info']['address']);
+        global $name_1, $personal_info_1, $name_2, $personal_info_2, $name_3, $personal_info_3;
+        $this->assertEquals("baz\'piyo_get", $name_1);
+        $this->assertEquals("baz\'piyo_get", $_GET['name_1']);
+        $this->assertEquals("\'Okinawa\'", $personal_info_1['address']);
+        $this->assertEquals("\'Okinawa\'", $_GET['personal_info_1']['address']);
+
+        $this->assertEquals("baz\'piyo_post", $name_2);
+        $this->assertEquals("baz\'piyo_post", $_POST['name_2']);
+        $this->assertEquals("\'Tokyo\'", $personal_info_2['address']);
+        $this->assertEquals("\'Tokyo\'", $_POST['personal_info_2']['address']);
+
+        $this->assertEquals("baz\'piyo_cookie", $name_3);
+        $this->assertEquals("baz\'piyo_cookie", $_COOKIE['name_3']);
+        $this->assertEquals("\'Kanagawa\'", $personal_info_3['address']);
+        $this->assertEquals("\'Kanagawa\'", $_COOKIE['personal_info_3']['address']);
+
+        $this->assertEquals("baz\'piyo_get", $_REQUEST['name_1']);
+        $this->assertEquals("\'Okinawa\'", $_REQUEST['personal_info_1']['address']);
+        $this->assertEquals("baz\'piyo_post", $_REQUEST['name_2']);
+        $this->assertEquals("\'Tokyo\'", $_REQUEST['personal_info_2']['address']);
+        $this->assertEquals("baz\'piyo_cookie", $_REQUEST['name_3']);
+        $this->assertEquals("\'Kanagawa\'", $_REQUEST['personal_info_3']['address']);
     }
 
     /**


### PR DESCRIPTION
Hi, I suggest improvements.

magic quotes gpc adds addslashes to $ _GET, $ _POST, $ _COOKIE, and $ _REQUEST.
However, $ _REQUEST is not currently converted.
So I fixed it.

### Example

Run the following code.

```php
<?php

require_once './vendor/autoload.php';
require_once './src/Request.php';

$request = new Gongo\MercifulPolluter\Request();
$request->enableMagicQuotesGpc();
$request->pollute();

var_dump($_GET);
var_dump($_POST);
var_dump($_COOKIE);
var_dump($_REQUEST);
```

#### Before

```php
curl 'http://localhost/?hoge=ho"ge' -X POST -d "huga=hu'ga" -b 'piyo=pi\yo'
array(1) {
  ["hoge"]=>
  string(6) "ho\"ge"
}
array(1) {
  ["huga"]=>
  string(6) "hu\'ga"
}
array(1) {
  ["piyo"]=>
  string(6) "pi\\yo"
}
array(3) {
  ["hoge"]=>
  string(5) "ho"ge"
  ["huga"]=>
  string(5) "hu'ga"
  ["piyo"]=>
  string(5) "pi\yo"
}
```

#### After

```php
curl 'http://localhost/?hoge=ho"ge' -X POST -d "huga=hu'ga" -b 'piyo=pi\yo'
array(1) {
  ["hoge"]=>
  string(6) "ho\"ge"
}
array(1) {
  ["huga"]=>
  string(6) "hu\'ga"
}
array(1) {
  ["piyo"]=>
  string(6) "pi\\yo"
}
array(3) {
  ["hoge"]=>
  string(6) "ho\"ge"
  ["huga"]=>
  string(6) "hu\'ga"
  ["piyo"]=>
  string(6) "pi\\yo"
}
```