### PR TITLE
Use recursive merge when overwriting an array to an array.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -133,7 +133,11 @@ class Request extends Base
                 continue;
             }
 
-            $GLOBALS[$name] = $value;
+            if (is_array($GLOBALS[$name]) && is_array($value)) {
+                $GLOBALS[$name] = array_replace_recursive($GLOBALS[$name], $value);
+            } else {
+                $GLOBALS[$name] = $value;
+            }
         }
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -133,7 +133,7 @@ class Request extends Base
                 continue;
             }
 
-            if (is_array($GLOBALS[$name]) && is_array($value)) {
+            if (isset($GLOBALS[$name]) && is_array($GLOBALS[$name]) && is_array($value)) {
                 $GLOBALS[$name] = array_replace_recursive($GLOBALS[$name], $value);
             } else {
                 $GLOBALS[$name] = $value;

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -7,7 +7,7 @@ use Gongo\MercifulPolluter\Request;
 class RequestTest extends PHPUnit_Framework_TestCase
 {
     private $object = null;
-    
+
     protected function setUp()
     {
         $this->object = $this->getMockBuilder('Gongo\MercifulPolluter\Request')
@@ -26,7 +26,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $_POST['article_id'] = 99999;
         $_GET['secret_info'] = array('address' => "'Okinawa'");
         $_COOKIE['session_id'] = 'SESSIONID';
-        
+
         $this->setVariablesOrder('EGPCS');
         $this->object->pollute();
 
@@ -79,7 +79,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
     {
         $_GET['id'] = 'get';
         $_POST['id'] = 'post';
-        
+
         $this->setVariablesOrder('gpg');
         $this->object->pollute();
 
@@ -87,12 +87,94 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($_POST['id'], $id);
     }
 
+    public function testPolluteOverwriteArrayToArray()
+    {
+        $_GET['foo'] = array('bar' => 'baz');
+        $_POST['foo'] = array('spam' => 'ham');
+
+        $this->setVariablesOrder('gp');
+        $this->object->pollute();
+
+        global $foo;
+        $this->assertEquals(array('bar' => 'baz', 'spam' => 'ham'), $foo);
+    }
+
+    public function testPolluteOverwriteNestedArrayToNestedArray()
+    {
+        $_GET['foo'] = array('bar' => array('baz' => '123'));
+        $_POST['foo'] = array('bar' => array('spam' => 'ham'));
+
+        $this->setVariablesOrder('gp');
+        $this->object->pollute();
+
+        global $foo;
+        $this->assertEquals(
+            array(
+                'bar' => array(
+                    'baz' => '123',
+                    'spam' => 'ham'
+                )
+            ),
+            $foo
+        );
+    }
+
+    public function testPolluteOverwriteScalarToArray()
+    {
+        $_GET['foo'] = 'bar';
+        $_POST['foo'] = array('spam' => 'ham');
+
+        $this->setVariablesOrder('gp');
+        $this->object->pollute();
+
+        global $foo;
+        $this->assertEquals(array('spam' => 'ham'), $foo);
+    }
+
+    public function testPolluteOverwriteArrayToScalar()
+    {
+        $_GET['foo'] = array('bar' => 'baz');
+        $_POST['foo'] = 'ham';
+
+        $this->setVariablesOrder('gp');
+        $this->object->pollute();
+
+        global $foo;
+        $this->assertEquals('ham', $foo);
+    }
+
+    public function testPolluteOverwriteArrayToScalarToArray()
+    {
+        $_GET['foo'] = array('bar' => 'baz');
+        $_POST['foo'] = 'ham';
+        $_COOKIE['foo'] = array('spam' => 'ham');
+
+        $this->setVariablesOrder('gpc');
+        $this->object->pollute();
+
+        global $foo;
+        $this->assertEquals(array('spam' => 'ham'), $foo);
+    }
+
+    public function testPolluteOverwriteArrayToArrayToScalar()
+    {
+        $_GET['foo'] = array('bar' => 'baz');
+        $_POST['foo'] = array('spam' => 'ham');
+        $_COOKIE['foo'] = 'ham';
+
+        $this->setVariablesOrder('gpc');
+        $this->object->pollute();
+
+        global $foo;
+        $this->assertEquals('ham', $foo);
+    }
+
     public function testPolluteEnableMagicQuotesGpc()
     {
         $_ENV['TOKEN'] = "foo'bar";
         $_GET['secret_id'] = "baz'piyo";
         $_GET['secret_info'] = array('address' => "'Okinawa'");
-        
+
         $this->setVariablesOrder('eg');
         $this->object->enableMagicQuotesGpc();
         $this->object->pollute();
@@ -133,7 +215,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('baz', $_GET['bar']);
         $this->assertEquals('baz', $bar);
     }
-    
+
     private function setVariablesOrder($value)
     {
         $this->object->method('getInjectVariables')


### PR DESCRIPTION
## Motivation

I found that there is a problem when an array is overwritten to a global variable that already has an array set.

## Steps to reproduce

Server:

```php
<?php

if (version_compare(PHP_VERSION, '5.4.0', '>')) {
    require_once './vendor/autoload.php';

    $request = new Gongo\MercifulPolluter\Request;
    $request->pollute();
}

var_dump($foo);
```

Client:

```console
$ curl 'http://localhost?foo\[bar\]\[a\]=123' -X POST -d "foo[bar][b]=789"
```

## Expected behavior

PHP 5.3.29 (with `register_globals = 'On'`)

```php
array(1) {
  ["bar"]=>
  array(2) {
    ["a"]=> string(3) "123"
    ["b"]=> string(3) "789"
  }
}
```

## Actual behavior

PHP 7.1 with merciful-polluter

```php
array(1) {
  ["bar"]=>
  array(1) {
    ["b"]=> string(3) "789"
  }
}
```

## References

https://github.com/php/php-src/blob/php-5.3.29/main/php_variables.c#L636

1. When `Scalar to Array` or `Array to Scalar`:

    Just overwirte.

    ```php
    // ini_get('variables_order') => 'GP'
    $_GET['foo'] => '123',
    $_POST['foo'] => array('piyo' => '789');
    $foo // => array('piyo' => '789');

    $_GET['bar'] => array('baz' => '456');
    $_POST['bar'] => 'abcde';
    $bar // => 'abcde'
    ```

2. `Array to Array`:

    Like `array_merge_recursive`