### PR TITLE
Correspond to PHPUnit warning for E_USER_WARNING expectation.

### DIFF
--- a/test/SessionTest.php
+++ b/test/SessionTest.php
@@ -32,21 +32,27 @@ class SessionTest extends TestCase
     }
 
     /**
-     * Below annotations are for PHPUnit < 9.0
+     * NOTE: Why not use `@expectedException` or `$this->expectWarning()` ?
      *
-     * @expectedException PHPUnit_Framework_Error_Warning
-     * @expectedExceptionMessage The session not yet started (Ignoring)
+     * Expecting E_WARNING and E_USER_WARNING is deprecated and will no longer be possible in PHPUnit 10.
+     *
+     * @see https://phpunit.de/announcements/phpunit-10.html
+     * @see https://codeseekah.com/2023/03/01/testing-warnings-in-phpunit-9/
      */
     public function testPolluteSessionNotStarted()
     {
-        // For PHPUnit >= 9.0
-        if (method_exists($this, 'expectWarning')) {
-            $this->expectWarning();
-            $this->expectWarningMessage('The session not yet started (Ignoring)');
-        }
+        $errored = null;
+        set_error_handler(function($errno, $errstr) use (&$errored) {
+            $errored = [$errno, $errstr];
+            restore_error_handler();
+        });
         
         $this->object = new Session;
         $this->object->pollute();
+
+        [$errno, $errstr] = $errored;
+        $this->assertEquals(E_USER_WARNING, $errno);
+        $this->assertEquals('The session not yet started (Ignoring)', $errstr);
     }
 
     /**

--- a/test/SessionTest.php
+++ b/test/SessionTest.php
@@ -50,7 +50,7 @@ class SessionTest extends TestCase
         $this->object = new Session;
         $this->object->pollute();
 
-        [$errno, $errstr] = $errored;
+        list($errno, $errstr) = $errored;
         $this->assertEquals(E_USER_WARNING, $errno);
         $this->assertEquals('The session not yet started (Ignoring)', $errstr);
     }


### PR DESCRIPTION
## Motivation

https://github.com/gongo/merciful-polluter/actions/runs/6018004016/job/16325402122

```
PHPUnit 9.6.11 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.............W.                                                   15 / 15 ([10](https://github.com/gongo/merciful-polluter/actions/runs/6018004016/job/16325402122#step:7:11)0%)

Time: 00:00.528, Memory: [12](https://github.com/gongo/merciful-polluter/actions/runs/6018004016/job/16325402122#step:7:13).00 MB

There was 1 warning:

1) Gongo\MercifulPolluter\Test\SessionTest::testPolluteSessionNotStarted
Expecting E_WARNING and E_USER_WARNING is deprecated and will no longer be possible in PHPUnit 10.

WARNINGS!
Tests: [15](https://github.com/gongo/merciful-polluter/actions/runs/6018004016/job/16325402122#step:7:16), Assertions: 68, Warnings: 1.

Generating code coverage report in Clover XML format ... done [00:00.012]
```