### PR TITLE
Resolve deprecated warning

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -54,7 +54,7 @@ class Request extends Base
                 if ($key === 'tmp_name') {
                     $name = $field;
                 } else {
-                    $name = "${field}_${key}";
+                    $name = "{$field}_{$key}";
                 }
                 $values[$name] = $value;
             }


### PR DESCRIPTION
```
Deprecated: Using ${var} in strings is deprecated, use {$var} instead
```